### PR TITLE
updating streaks to track from start date instead of sundays

### DIFF
--- a/src/firebase/services/helpers.ts
+++ b/src/firebase/services/helpers.ts
@@ -1,7 +1,7 @@
 import type { UserStats } from '../types/userType';
 
 /**
- * Gets the start date (Sunday) of the week containing the provided date
+ * Gets the start date of the week containing the provided date
  * Returns it as an ISO string
  */
 export function getWeekStartDate(date: Date = new Date()): string {
@@ -9,6 +9,29 @@ export function getWeekStartDate(date: Date = new Date()): string {
   sunday.setDate(date.getDate() - date.getDay());
   sunday.setHours(0, 0, 0, 0);
   return sunday.toISOString();
+}
+
+/**
+ * Gets personal week start date for a user based on their creation date
+ * Returns current period start date as an ISO string
+ */
+export function getPersonalWeekStart(registrationDate: string, today: Date = new Date()): string {
+  const startDate = new Date(registrationDate);
+  startDate.setHours(0, 0, 0, 0);
+
+  const todayDate = new Date(today);
+  todayDate.setHours(0, 0, 0, 0);
+
+  const daysSinceRegistration = Math.floor(
+    (todayDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  const completedPeriods = Math.floor(daysSinceRegistration / 7);
+
+  const currentPeriodStart = new Date(startDate);
+  currentPeriodStart.setDate(startDate.getDate() + completedPeriods * 7);
+
+  return currentPeriodStart.toISOString();
 }
 
 /**

--- a/src/firebase/services/statService.ts
+++ b/src/firebase/services/statService.ts
@@ -1,10 +1,9 @@
-import { db } from "$lib/helpers/firebase";
-import { doc, getDoc, updateDoc, collection, getDocs } from "firebase/firestore";
-import type { User, AssignedExercise, UserStats } from "../types/userType";
-import { getUser, updateUser } from "./userService";
-import { getWeekStartDate, initializeUserStats } from "./helpers";
-import { getCurrentProgram, updateProgram } from "./programService";
-import { checkAchievements } from "./milestoneService";
+import { db } from '$lib/helpers/firebase';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import type { User, AssignedExercise, UserStats } from '../types/userType';
+import { getUser, updateUser } from './userService';
+import { getWeekStartDate, getPersonalWeekStart, initializeUserStats } from './helpers';
+import { checkAchievements } from './milestoneService';
 
 export { initializeUserStats };
 
@@ -15,14 +14,14 @@ export { initializeUserStats };
  */
 
 export async function getUserStats(userId: string): Promise<UserStats | null> {
-    try {
-        const userRef = doc(db, "users", userId);
-        const userSnap = await getDoc(userRef);
-        return userSnap.exists() ? (userSnap.data().stats as UserStats) : null;
-    } catch (error) {
-        console.error(`Error getting stats for user ${userId}:`, error);
-        return null;
-    }
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    return userSnap.exists() ? (userSnap.data().stats as UserStats) : null;
+  } catch (error) {
+    console.error(`Error getting stats for user ${userId}:`, error);
+    return null;
+  }
 }
 
 /* ---------------------- UPDATE USER STATS AFTER EXERCISE ---------------------- */
@@ -33,31 +32,29 @@ export async function getUserStats(userId: string): Promise<UserStats | null> {
  */
 
 export async function updateUserStats(userId: string, exercise: AssignedExercise) {
-    try {
-        const userRef = doc(db, "users", userId);
-        const userSnap = await getDoc(userRef);
-        if (!userSnap.exists()) return;
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    if (!userSnap.exists()) return;
 
-        let { stats } = userSnap.data();
+    let { stats } = userSnap.data();
 
-        if (exercise.exerciseType === 'distance') {
-            stats.totalSets += exercise.sets ?? 0;
-            stats.totalDistance += (exercise.steps ?? 0) * (exercise.sets ?? 0);
-        } 
-        else if (exercise.exerciseType === 'weight') {
-            stats.totalSets += exercise.sets ?? 0;
-            stats.totalReps += (exercise.reps ?? 0) * (exercise.sets ?? 0);
-            stats.totalWeight += (exercise.weight ?? 0) * (exercise.reps ?? 0) * (exercise.sets ?? 0);
-        }
-        else if (exercise.exerciseType === 'time') {
-            stats.totalTime += (exercise.seconds ?? 0) * (exercise.reps ?? 0);
-        }
-
-        await updateDoc(userRef, { stats });
-        await checkAchievements(userId);
-    } catch (error) {
-        console.error(`Error updating stats for user ${userId}:`, error);
+    if (exercise.exerciseType === 'distance') {
+      stats.totalSets += exercise.sets ?? 0;
+      stats.totalDistance += (exercise.steps ?? 0) * (exercise.sets ?? 0);
+    } else if (exercise.exerciseType === 'weight') {
+      stats.totalSets += exercise.sets ?? 0;
+      stats.totalReps += (exercise.reps ?? 0) * (exercise.sets ?? 0);
+      stats.totalWeight += (exercise.weight ?? 0) * (exercise.reps ?? 0) * (exercise.sets ?? 0);
+    } else if (exercise.exerciseType === 'time') {
+      stats.totalTime += (exercise.seconds ?? 0) * (exercise.reps ?? 0);
     }
+
+    await updateDoc(userRef, { stats });
+    await checkAchievements(userId);
+  } catch (error) {
+    console.error(`Error updating stats for user ${userId}:`, error);
+  }
 }
 
 /* ---------------------- RESET USER'S DAILY PROGRESS AT MIDNIGHT ---------------------- */
@@ -68,35 +65,35 @@ export async function updateUserStats(userId: string, exercise: AssignedExercise
  */
 
 export async function resetDailyProgress(userId: string) {
-    try {
-        const programRef = doc(db, `users/${userId}/program/currentProgram`);
-        const programSnap = await getDoc(programRef);
-        
-        if (programSnap.exists()) {
-            const programData = programSnap.data();
-            const _today = new Date().toISOString().split("T")[0];
-            
-            // Reset exercises for the new day
-            const updatedExercises = programData.exercises.map((exercise: AssignedExercise) => {
-                return { 
-                    ...exercise, 
-                    completed: false,
-                    completedAt: null,
-                    skipped: false 
-                };
-            });
+  try {
+    const programRef = doc(db, `users/${userId}/program/currentProgram`);
+    const programSnap = await getDoc(programRef);
 
-            await updateDoc(programRef, { 
-                exercises: updatedExercises,
-                completed: false
-            });
-        }
-    } catch (error) {
-        console.error(`Error resetting daily progress for user ${userId}:`, error);
+    if (programSnap.exists()) {
+      const programData = programSnap.data();
+      // const _today = new Date().toISOString().split('T')[0];
+
+      // Reset exercises for the new day
+      const updatedExercises = programData.exercises.map((exercise: AssignedExercise) => {
+        return {
+          ...exercise,
+          completed: false,
+          completedAt: null,
+          skipped: false
+        };
+      });
+
+      await updateDoc(programRef, {
+        exercises: updatedExercises,
+        completed: false
+      });
     }
+  } catch (error) {
+    console.error(`Error resetting daily progress for user ${userId}:`, error);
+  }
 }
 
-/* ---------------------- RESET WEEKLY PROGRESS (ONLY ON SUNDAYS) ---------------------- */
+/* ---------------------- RESET WEEKLY PROGRESS (BASED ON START DATE) ---------------------- */
 /**
  * Resets weekly progress every Sunday at midnight
  * - If user completed 5+ days in the week, increments their currentStreak
@@ -104,90 +101,78 @@ export async function resetDailyProgress(userId: string) {
  */
 
 export async function resetWeeklyProgress(userId: string) {
-    try {
-        const userRef = doc(db, "users", userId);
-        const userSnap = await getDoc(userRef);
-        if (!userSnap.exists()) return;
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    if (!userSnap.exists()) return;
 
-        let { stats } = userSnap.data();
-        const today = new Date().toISOString().split("T")[0];
-        const currentWeekStart = getWeekStartDate(new Date(today));
+    const userData = userSnap.data() as User;
+    let { stats } = userData;
+    const today = new Date();
 
-        if (stats.weeklyProgress.weekStartDate !== currentWeekStart) {
-            // If completed 5+ days, increment streak
-            if (stats.weeklyProgress.daysCompleted >= 5) {
-                stats.currentStreak += 1;
-            } else {
-                // Reset streak only if they didn't meet the weekly goal
-                stats.currentStreak = 0;
-            }
-            
-            // Start a new week
-            stats.weeklyProgress = { 
-                weekStartDate: currentWeekStart, 
-                daysCompleted: 0, 
-                exercisesCompleted: 0 
-            };
-            
-            await updateDoc(userRef, { stats });
+    const currentPersonalWeekStart = getPersonalWeekStart(userData.createdAt, today);
+
+    if (stats.weeklyProgress.weekStartDate !== currentPersonalWeekStart) {
+      if (stats.weeklyProgress.daysCompleted >= 5) {
+        stats.currentStreak += 1;
+
+        if (stats.currentStreak > stats.longestStreak) {
+          stats.longestStreak = stats.currentStreak;
         }
-    } catch (error) {
-        console.error(`Error resetting weekly progress for user ${userId}:`, error);
+      }
+
+      stats.weeklyProgress = {
+        weekStartDate: currentPersonalWeekStart,
+        daysCompleted: 0,
+        exercisesCompleted: 0
+      };
+
+      await updateDoc(userRef, { stats });
     }
+  } catch (error) {
+    console.error(`Error resetting weekly progress for user ${userId}:`, error);
+  }
 }
 
 /* ---------------------- CHECK & RESET PROGRESS ---------------------- */
 /**
  * Checks if it's a new day and performs necessary resets
- * Tracks the last check date
- * Calls resetDailyProgress for a new day and resetWeeklyProgress on Sundays
+ * Tracks the last check date from Firestore
+ * Calls resetDailyProgress for a new day and resetWeeklyProgress
  */
 
 export async function checkAndResetProgress(userId: string) {
-    try {
-        const programRef = doc(db, `users/${userId}/program/currentProgram`);
-        const programSnap = await getDoc(programRef);
-        
-        if (!programSnap.exists()) return;
-        
-        const programData = programSnap.data();
-        // const today = "2025-04-06"; // For testing purposes
-        const today = new Date().toISOString().split("T")[0]; // Format: YYYY-MM-DD
-        const lastResetDate = programData.lastResetDate || programData.assignedAt.split("T")[0];
-        
-        console.log("DEBUG - Today's date:", today);
-        console.log("DEBUG - Last reset date:", lastResetDate);
-        console.log("DEBUG - Dates equal?", lastResetDate === today);
-        console.log("DEBUG - Program data:", programData);
+  try {
+    const programRef = doc(db, `users/${userId}/program/currentProgram`);
+    const programSnap = await getDoc(programRef);
 
-        if (lastResetDate !== today) {
-            console.log("New day detected - performing daily reset");
-            
-            const updatedExercises = programData.exercises.map((exercise: AssignedExercise) => {
-                return { 
-                    ...exercise, 
-                    completed: false,
-                    completedAt: null,
-                    skipped: false 
-                };
-            });
+    if (!programSnap.exists()) return;
 
-            await resetDailyProgress(userId);
+    const programData = programSnap.data();
+    const today = new Date().toISOString().split('T')[0];
+    const lastResetDate = programData.lastResetDate || programData.assignedAt.split('T')[0];
 
-            await updateDoc(programRef, { 
-                exercises: updatedExercises,
-                completed: false,
-                lastResetDate: today
-            });
-            
-            if (new Date().getDay() === 0) {
-                console.log("Sunday detected - performing weekly reset");
-                await resetWeeklyProgress(userId);
-            }
-        }
-    } catch (error) {
-        console.error(`Error checking and resetting progress for user ${userId}:`, error);
+    if (lastResetDate !== today) {
+      const updatedExercises = programData.exercises.map((exercise: AssignedExercise) => {
+        return {
+          ...exercise,
+          completed: false,
+          completedAt: null,
+          skipped: false
+        };
+      });
+
+      await updateDoc(programRef, {
+        exercises: updatedExercises,
+        completed: false,
+        lastResetDate: today
+      });
+
+      await resetWeeklyProgress(userId);
     }
+  } catch (error) {
+    console.error(`Error checking and resetting progress for user ${userId}:`, error);
+  }
 }
 
 /* ---------------------- GET WEEKLY PROGRESS ---------------------- */
@@ -198,42 +183,44 @@ export async function checkAndResetProgress(userId: string) {
  */
 
 export async function getWeeklyProgress(userId: string): Promise<{
-    weekStartDate: string;
-    daysCompleted: number;
-    exercisesCompleted: number;
-    remainingDays: number;
-    daysNeededForStreak: number;
+  weekStartDate: string;
+  daysCompleted: number;
+  exercisesCompleted: number;
+  remainingDays: number;
+  daysNeededForStreak: number;
 }> {
-    try {
-        const stats = await getUserStats(userId);
-        if (!stats) throw new Error("User stats not found");
+  try {
+    const stats = await getUserStats(userId);
+    if (!stats) throw new Error('User stats not found');
 
-        // Initialize weekly progress if it doesn't exist
-        if (!stats.weeklyProgress) {
-            stats.weeklyProgress = {
-                weekStartDate: getWeekStartDate(),
-                daysCompleted: 0,
-                exercisesCompleted: 0
-            };
-        }
-
-        const today = new Date();
-        const weekStart = new Date(stats.weeklyProgress.weekStartDate);
-        const daysSinceStart = Math.floor((today.getTime() - weekStart.getTime()) / (1000 * 60 * 60 * 24));
-        
-        const remainingDays = Math.max(0, 7 - daysSinceStart);
-        
-        const daysNeededForStreak = Math.max(0, 5 - stats.weeklyProgress.daysCompleted);
-
-        return { 
-            ...stats.weeklyProgress, 
-            remainingDays,
-            daysNeededForStreak
-        };
-    } catch (error) {
-        console.error(`Error getting weekly progress for user ${userId}:`, error);
-        throw error;
+    // Initialize weekly progress if it doesn't exist
+    if (!stats.weeklyProgress) {
+      stats.weeklyProgress = {
+        weekStartDate: getWeekStartDate(),
+        daysCompleted: 0,
+        exercisesCompleted: 0
+      };
     }
+
+    const today = new Date();
+    const weekStart = new Date(stats.weeklyProgress.weekStartDate);
+    const daysSinceStart = Math.floor(
+      (today.getTime() - weekStart.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    const remainingDays = Math.max(0, 7 - daysSinceStart);
+
+    const daysNeededForStreak = Math.max(0, 5 - stats.weeklyProgress.daysCompleted);
+
+    return {
+      ...stats.weeklyProgress,
+      remainingDays,
+      daysNeededForStreak
+    };
+  } catch (error) {
+    console.error(`Error getting weekly progress for user ${userId}:`, error);
+    throw error;
+  }
 }
 
 /* ---------------------- UPDATE STREAK ON PROGRAM COMPLETION ---------------------- */
@@ -245,31 +232,31 @@ export async function getWeeklyProgress(userId: string): Promise<{
  */
 
 export async function updateStreakOnCompletion(userId: string): Promise<void> {
-    try {
-        const user = await getUser(userId);
-        if (!user?.stats) return;
+  try {
+    const user = await getUser(userId);
+    if (!user?.stats) return;
 
-        // Only update streak if we haven't already completed today
-        if (await hasCompletedToday(userId)) return;
+    // Only update streak if we haven't already completed today
+    if (await hasCompletedToday(userId)) return;
 
-        const today = new Date();
-        const stats = { ...user.stats };
+    const today = new Date();
+    const stats = { ...user.stats };
 
-        // Add today's completion to streak history
-        stats.streakHistory.push({ date: today.toISOString(), completed: true });
-        stats.lastCompletedDate = today.toISOString();
+    // Add today's completion to streak history
+    stats.streakHistory.push({ date: today.toISOString(), completed: true });
+    stats.lastCompletedDate = today.toISOString();
 
-        // Update weekly progress if this is the current week
-        if (stats.weeklyProgress?.weekStartDate === getWeekStartDate(today)) {
-            // Cap at 5 days per week (our weekly target)
-            stats.weeklyProgress.daysCompleted = Math.min(5, stats.weeklyProgress.daysCompleted + 1);
-        }
-
-        await updateUser(userId, { stats });
-        await checkAchievements(userId);
-    } catch (error) {
-        console.error(`Error updating streak for user ${userId}:`, error);
+    // Update weekly progress if this is the current week
+    if (stats.weeklyProgress?.weekStartDate === getWeekStartDate(today)) {
+      // Cap at 5 days per week (our weekly target)
+      stats.weeklyProgress.daysCompleted = Math.min(5, stats.weeklyProgress.daysCompleted + 1);
     }
+
+    await updateUser(userId, { stats });
+    await checkAchievements(userId);
+  } catch (error) {
+    console.error(`Error updating streak for user ${userId}:`, error);
+  }
 }
 
 /**
@@ -277,17 +264,19 @@ export async function updateStreakOnCompletion(userId: string): Promise<void> {
  * Used to prevent duplicate streak updates on the same day
  */
 async function hasCompletedToday(userId: string): Promise<boolean> {
-    try {
-        const userRef = doc(db, "users", userId);
-        const userSnap = await getDoc(userRef);
-        if (!userSnap.exists()) return false;
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    if (!userSnap.exists()) return false;
 
-        const userData = userSnap.data() as User;
-        const today = new Date().toISOString().split("T")[0];
+    const userData = userSnap.data() as User;
+    const today = new Date().toISOString().split('T')[0];
 
-        return userData.stats.streakHistory.some(entry => entry.date.startsWith(today) && entry.completed);
-    } catch (error) {
-        console.error(`Error checking completion status for user ${userId}:`, error);
-        return false;
-    }
+    return userData.stats.streakHistory.some(
+      (entry) => entry.date.startsWith(today) && entry.completed
+    );
+  } catch (error) {
+    console.error(`Error checking completion status for user ${userId}:`, error);
+    return false;
+  }
 }

--- a/src/firebase/services/userexerciseService.ts
+++ b/src/firebase/services/userexerciseService.ts
@@ -60,21 +60,19 @@ export async function completeExercise(
     const seconds = adjustedValues?.seconds ?? exercise.seconds ?? 0;
     const weight = adjustedValues?.weight ?? exercise.weight ?? 0;
 
-        if (exercise.exerciseType === 'distance') {
-            stats.totalSets += sets;
-            stats.totalReps += steps;
-            stats.totalDistance += sets * steps;
-        } 
-        else if (exercise.exerciseType === 'weight') {
-            stats.totalSets += sets;
-            stats.totalReps += sets * reps;
-            stats.totalWeight += sets * reps * weight;
-        } 
-        else if (exercise.exerciseType === 'time') {
-            stats.totalSets += sets;
-            stats.totalReps += reps;
-            stats.totalTime += sets * reps * seconds;
-        }
+    if (exercise.exerciseType === 'distance') {
+      stats.totalSets += sets;
+      stats.totalReps += steps;
+      stats.totalDistance += sets * steps;
+    } else if (exercise.exerciseType === 'weight') {
+      stats.totalSets += sets;
+      stats.totalReps += sets * reps;
+      stats.totalWeight += sets * reps * weight;
+    } else if (exercise.exerciseType === 'time') {
+      stats.totalSets += sets;
+      stats.totalReps += reps;
+      stats.totalTime += sets * reps * seconds;
+    }
 
     const allCompleted = updatedExercises.every((ex) => ex.completed || ex.skipped);
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX change
- [ ] 🧹 Code refactor
- [x] ⚡ Performance improvement

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->

- [ ] Desktop (Chrome)
- [ ] Desktop (Firefox)
- [ ] Desktop (Safari)
- [ ] Mobile (iOS)
- [ ] Mobile (Android)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
simply updating the streaks logic to reset 7 days from whatever the user's startdate is, instead of sundays

<!-- Add any other context about the PR here -->

## Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] My code follows the style guidelines of this project
- [ ] I have tested my changes on multiple browsers/devices
- [ ] My changes match the Figma designs (if applicable)
- [ ] All existing tests pass
- [ ] I have tested and proved my fix/feature works

/assign_reviewer @alexisraya @simprina
