### PR TITLE
Exercise Info Block Fixed

### DIFF
--- a/src/lib/design-system/components/ExerciseInfoBlock.svelte
+++ b/src/lib/design-system/components/ExerciseInfoBlock.svelte
@@ -220,7 +220,7 @@
   }
   .exercise_info {
     position: relative;
-    bottom: 15px;
+    display: block;
     background: var(--color-grey-opactity-dark); /* light/dark mode exception */
     border-radius: 30px;
     color: var(--text-primary);

--- a/src/lib/design-system/components/ExerciseModel.svelte
+++ b/src/lib/design-system/components/ExerciseModel.svelte
@@ -7,6 +7,24 @@
   export let modelPath = ''; // Path to the 3D model
   let container;
   let mixer; // Animation mixer
+
+  function handleResize() {
+    if (!container) return;
+
+    // Force a specific aspect ratio if needed
+    const aspectRatio = 9 / 16; // Or whatever ratio works best for your model
+
+    // Check what layout we're in (mobile vs desktop)
+    const isMobile = window.innerWidth < 800;
+
+    // Set a consistent height based on width and aspect ratio
+    if (isMobile) {
+      container.style.height = `${container.clientWidth / aspectRatio}px`;
+    } else {
+      // For desktop you might want a different approach
+      container.style.height = '50vh'; // Or another value
+    }
+  }
   // limit zoom in and out, x axis, y axis. intial camera view
   onMount(() => {
     const scene = new THREE.Scene();
@@ -75,16 +93,22 @@
 
     // Handle window resize
     const onWindowResize = () => {
+      if (!container) return;
       camera.aspect = container.clientWidth / container.clientHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(container.clientWidth, container.clientHeight);
     };
 
-    window.addEventListener('resize', onWindowResize);
+    // Call resize handler initially and on window resize
+    handleResize();
+    window.addEventListener('resize', () => {
+      handleResize();
+      onWindowResize();
+    });
 
     // Cleanup
     return () => {
-      window.removeEventListener('resize', onWindowResize);
+      window.removeEventListener('resize', handleResize);
     };
   });
 </script>
@@ -95,7 +119,7 @@
 <style>
   .three-canvas {
     width: 100%;
-    height: 100%;
     background: transparent;
+    min-height: 385px;
   }
 </style>

--- a/src/routes/your-program/[exerciseId]/+page.svelte
+++ b/src/routes/your-program/[exerciseId]/+page.svelte
@@ -288,7 +288,6 @@
         </a>
         <ProgressBar totalExercises={program.exercises.length} {completedExercises} />
       </div>
-
       <ExerciseModel modelPath="/models/SmallTest2.glb" />
       <div class="exercise-info-container">
         <ExerciseInfoBlock
@@ -619,12 +618,26 @@
   }
 
   .exercise-info-container {
+    display: block;
     position: relative;
-    bottom: 112px;
+    bottom: 12px;
   }
 
   .hide-mobile {
     display: none;
+  }
+
+  .exercise_container--top {
+    /* Other existing styles */
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Create a dedicated container for the model with fixed proportions */
+  :global(.exercise-model) {
+    width: 100%;
+    /* Don't set height here - let the component handle it */
+    margin: 20px 0;
   }
 
   /* Media query for screens larger than 800px */
@@ -653,6 +666,10 @@
       padding: 20px;
       justify-content: center;
       position: relative; /* For positioning child elements */
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding-top: 150px;
     }
 
     /* Right half - Exercise info/controls */
@@ -740,7 +757,20 @@
     }
 
     .exercise-info-container {
-      bottom: 0px;
+      bottom: 0;
+      position: relative;
+    }
+  }
+  @media screen and (max-width: 799px) {
+    .exercise_container-bottom::before {
+      content: none; /* Remove the pseudo-element on mobile */
+      display: none;
+      height: 0;
+    }
+
+    .exercise_container--top :global(.exercise-model) {
+      margin-top: auto; /* Reset the margin */
+      flex: none; /* Reset the flex property */
     }
   }
 </style>


### PR DESCRIPTION
## Description

This problem was caused by the way exercise model scaled up with different page sizes. When shrinking from a larger page size, the screen would not recognize that it had adapted and the exercise model would end up with a larger height than it started with.

This is fixed by adding an aspect ratio and minimum height with some parameters to make sure it runs correctly.

## Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX change
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->

- [x] Desktop (Chrome)
- [x] Desktop (Firefox)
- [x] Desktop (Safari)
- [ ] Mobile (iOS)
- [ ] Mobile (Android)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
![Screenshot 2025-04-21 at 10 31 57 PM](https://github.com/user-attachments/assets/a4ce4854-55fa-4233-9d13-30281108c819)

## Additional Notes

<!-- Add any other context about the PR here -->

## Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] My code follows the style guidelines of this project
- [x] I have tested my changes on multiple browsers/devices
- [x] My changes match the Figma designs (if applicable)
- [x] All existing tests pass
- [x] I have tested and proved my fix/feature works

/assign_reviewer @alexisraya @simprina
